### PR TITLE
fix init conc bug

### DIFF
--- a/R/camkii_ode_det.R
+++ b/R/camkii_ode_det.R
@@ -40,7 +40,6 @@ detSim_camkii <- function(input_df, input_sim_params, input_model_params) {
                                              Kd = 1000,
                                              Vm_phos = 0.005,
                                              Kd_phos = 0.3,
-                                             totalC = 800,
                                              h = 4.0))
   ################################# - Model - ################################
   ############################################################################
@@ -153,6 +152,7 @@ detSim_camkii <- function(input_df, input_sim_params, input_model_params) {
       # helper functions
       #vol <- 5e-15
       #f <- 6.0221415e+14 * vol
+      totalC <- W_I + W_B + W_P + W_T + W_A
       activeSubunits <- (W_B + W_P + W_T + W_A) / totalC
       prob <-  a * activeSubunits + b * activeSubunits^2 + c_ * activeSubunits^3
       # define model ODEs

--- a/src/camkii_model.cpp
+++ b/src/camkii_model.cpp
@@ -48,7 +48,6 @@ static std::map <std::string, double> prop_params_map;
 //' * Kd = 1000
 //' * Vm_phos = 0.005
 //' * Kd_phos = 0.3
-//' * totalC = 800
 //' * h = 4.0
 //' @md
 //' @return the result of calling the model specific version of the function "simulator" 
@@ -183,7 +182,6 @@ List init() {
     _["Kd"] = 1000,
     _["Vm_phos"] = 0.005,
     _["Kd_phos"] = 0.3,
-    _["totalC"] = 800,
     _["h"] = 4.0
   );
     
@@ -219,12 +217,12 @@ void calculate_amu() {
   double Kd = prop_params_map["Kd"];
   double Vm_phos = prop_params_map["Vm_phos"];
   double Kd_phos = prop_params_map["Kd_phos"];
-  double totalC = prop_params_map["totalC"];
   double h = prop_params_map["h"];
   
   amu[0] = x[0] * ((k_IB * camT * pow((double)calcium[ntimepoint],(double)h)) / (pow((double)calcium[ntimepoint],(double)h) + pow((double)Kd,(double)h)));
   amu[1] = amu[0] + k_BI * x[1];
   
+  double totalC = x[0] + x[1] + x[2] + x[3] + x[4];
   double activeSubunits = (x[1] + x[2] + x[3] + x[4]) / (totalC*f);
   double prob =  a * activeSubunits + b*(pow((double)activeSubunits,(double)2)) + c*(pow((double)activeSubunits,(double)3));
   amu[2] = amu[1] +  (totalC*f) * k_AA * prob * ((c_B * x[1]) / pow((double)(totalC*f),(double)2)) * (2*c_B*x[1] + c_P*x[2] + c_T*x[3]+ c_A*x[4]);


### PR DESCRIPTION
I found a potential bug in the current implementation of the `camkii` models. The model parameter, `totalC`, intended to describe the total amount of enzyme in the simulation, remains unchanged if the user changes the initial concentrations.

![camkii_initconc_bug](https://user-images.githubusercontent.com/23213428/220577799-a1db4e1c-9df3-4f75-bc9f-36511db8b7ca.png)

Here is a figure that illustrates the current behavior of the model for three different cases: when the initial concentrations and `totalC` parameters match (first plot), when only the initial concentration is changed (`totalC` remains unchanged; second plot), and when the `totalC` parameter is adjusted according to the initial concentration (third plot).

To address this issue, I suggest the following changes:
 - Remove the `totalC` parameter from the default parameters list.
 - Define the `totalC` parameter locally in the model calculation, ensuring it is calculated based on the initial concentrations.

The above suggestions are implemented in my branch `bugfix_camkii_initconc`. Please review my proposed changes and let me know if something needs to be changed.